### PR TITLE
사용자 추가 API 만들기

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -47,6 +47,9 @@ dependencies {
 	compileOnly 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
 
+	// DozerMapper
+	implementation 'com.github.dozermapper:dozer-core:6.4.0'
+
 	// Spring Boot Test
 	testImplementation('org.springframework.boot:spring-boot-starter-test') {
 		exclude group: 'org.junit.vintage', module: 'junit-vintage-engine'

--- a/app/src/main/java/com/codesoom/project/App.java
+++ b/app/src/main/java/com/codesoom/project/App.java
@@ -1,7 +1,10 @@
 package com.codesoom.project;
 
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.core.Mapper;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 
 @SpringBootApplication
 public class App {
@@ -10,4 +13,8 @@ public class App {
 		SpringApplication.run(App.class, args);
 	}
 
+	@Bean
+	public Mapper dozerMapper() {
+		return DozerBeanMapperBuilder.buildDefault();
+	}
 }

--- a/app/src/main/java/com/codesoom/project/core/application/UserService.java
+++ b/app/src/main/java/com/codesoom/project/core/application/UserService.java
@@ -1,2 +1,35 @@
-package com.codesoom.project.core.application;public class UserService {
+package com.codesoom.project.core.application;
+
+import com.codesoom.project.core.domain.User;
+import com.codesoom.project.core.domain.UserRepository;
+import com.codesoom.project.web.dto.UserRegistrationData;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+/**
+ * 사용자에 관한 유즈케이스를 담당합니다.
+ */
+@Service
+@Transactional
+public class UserService {
+    private final UserRepository userRepository;
+
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    /**
+     * 사용자를 등록한다.
+     *
+     * @param registrationData 등록하기 위한 데이터
+     * @return 등록된 사용자
+     */
+    public User createUser(UserRegistrationData registrationData) {
+
+        User user = userRepository.save(
+                mapper.map(registrationData, User.class));
+
+        return user;
+    }
 }

--- a/app/src/main/java/com/codesoom/project/core/application/UserService.java
+++ b/app/src/main/java/com/codesoom/project/core/application/UserService.java
@@ -1,0 +1,2 @@
+package com.codesoom.project.core.application;public class UserService {
+}

--- a/app/src/main/java/com/codesoom/project/core/application/UserService.java
+++ b/app/src/main/java/com/codesoom/project/core/application/UserService.java
@@ -3,6 +3,7 @@ package com.codesoom.project.core.application;
 import com.codesoom.project.core.domain.User;
 import com.codesoom.project.core.domain.UserRepository;
 import com.codesoom.project.web.dto.UserRegistrationData;
+import com.github.dozermapper.core.Mapper;
 import org.springframework.stereotype.Service;
 
 import javax.transaction.Transactional;
@@ -13,9 +14,11 @@ import javax.transaction.Transactional;
 @Service
 @Transactional
 public class UserService {
+    private final Mapper mapper;
     private final UserRepository userRepository;
 
-    public UserService(UserRepository userRepository) {
+    public UserService(Mapper mapper, UserRepository userRepository) {
+        this.mapper = mapper;
         this.userRepository = userRepository;
     }
 

--- a/app/src/main/java/com/codesoom/project/core/domain/User.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/User.java
@@ -1,2 +1,27 @@
-package com.codesoom.project.core.domain;public class User {
+package com.codesoom.project.core.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @Builder.Default
+    private String email = "";
+
+    @Builder.Default
+    private String name = "";
 }

--- a/app/src/main/java/com/codesoom/project/core/domain/User.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/User.java
@@ -1,0 +1,2 @@
+package com.codesoom.project.core.domain;public class User {
+}

--- a/app/src/main/java/com/codesoom/project/core/domain/UserRepository.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/UserRepository.java
@@ -1,0 +1,5 @@
+package com.codesoom.project.core.domain;
+
+public interface UserRepository {
+    User save(User user);
+}

--- a/app/src/main/java/com/codesoom/project/core/infra/JpaUserRepository.java
+++ b/app/src/main/java/com/codesoom/project/core/infra/JpaUserRepository.java
@@ -1,0 +1,12 @@
+package com.codesoom.project.core.infra;
+
+import com.codesoom.project.core.domain.User;
+import com.codesoom.project.core.domain.UserRepository;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface JpaUserRepository
+        extends UserRepository, CrudRepository<User, Long> {
+    User save(User user);
+}

--- a/app/src/main/java/com/codesoom/project/web/controller/UserController.java
+++ b/app/src/main/java/com/codesoom/project/web/controller/UserController.java
@@ -1,0 +1,28 @@
+package com.codesoom.project.web.controller;
+
+import com.codesoom.project.web.dto.UserRegistrationData;
+import com.codesoom.project.web.dto.UserResultData;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+@RestController
+@RequestMapping("/users")
+public class UserController {
+    /**
+     * 신규 사용자을 등록하고, 등록한 사용자을 반환합니다.
+     *
+     * @param registrationData 신규 사용자 정보
+     * @return 등록한 사용자
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    UserResultData create(@RequestBody @Valid UserRegistrationData registrationData) {
+        return null;
+    }
+}

--- a/app/src/main/java/com/codesoom/project/web/controller/UserController.java
+++ b/app/src/main/java/com/codesoom/project/web/controller/UserController.java
@@ -3,6 +3,7 @@ package com.codesoom.project.web.controller;
 import com.codesoom.project.web.dto.UserRegistrationData;
 import com.codesoom.project.web.dto.UserResultData;
 import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -11,9 +12,17 @@ import org.springframework.web.bind.annotation.RestController;
 
 import javax.validation.Valid;
 
+/**
+ * 사용자에 관련 요청을 처리하고 그에 따른 응답을 담당합니다.
+ */
 @RestController
 @RequestMapping("/users")
 public class UserController {
+
+    public UserController() {
+
+    }
+
     /**
      * 신규 사용자을 등록하고, 등록한 사용자을 반환합니다.
      *
@@ -23,6 +32,21 @@ public class UserController {
     @PostMapping
     @ResponseStatus(HttpStatus.CREATED)
     UserResultData create(@RequestBody @Valid UserRegistrationData registrationData) {
-        return null;
+        return UserResultData.builder()
+                .email(registrationData.getEmail())
+                .name(registrationData.getName())
+                .build();
+    }
+
+    private UserResultData getUserResultData(User user) {
+        if (user == null) {
+            return null;
+        }
+
+        return UserResultData.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .name(user.getName())
+                .build();
     }
 }

--- a/app/src/main/java/com/codesoom/project/web/dto/UserRegistrationData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/UserRegistrationData.java
@@ -1,5 +1,6 @@
 package com.codesoom.project.web.dto;
 
+import com.github.dozermapper.core.Mapping;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -11,8 +12,10 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class UserRegistrationData {
     @NotBlank
+    @Mapping("email")
     private String email;
 
     @NotBlank
+    @Mapping("name")
     private String name;
 }

--- a/app/src/main/java/com/codesoom/project/web/dto/UserRegistrationData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/UserRegistrationData.java
@@ -1,0 +1,18 @@
+package com.codesoom.project.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserRegistrationData {
+    @NotBlank
+    private String email;
+
+    @NotBlank
+    private String name;
+}

--- a/app/src/main/java/com/codesoom/project/web/dto/UserResultData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/UserResultData.java
@@ -3,10 +3,12 @@ package com.codesoom.project.web.dto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 public class UserResultData {
     private Long id;
 

--- a/app/src/main/java/com/codesoom/project/web/dto/UserResultData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/UserResultData.java
@@ -1,0 +1,16 @@
+package com.codesoom.project.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class UserResultData {
+    private Long id;
+
+    private String email;
+
+    private String name;
+}

--- a/app/src/test/java/com/codesoom/project/helper/UTF8EncodingFilter.java
+++ b/app/src/test/java/com/codesoom/project/helper/UTF8EncodingFilter.java
@@ -1,0 +1,26 @@
+package com.codesoom.assignment;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@AutoConfigureMockMvc
+@Import({UTF8EncodingFilter.Sample.class})
+public @interface UTF8EncodingFilter {
+    class Sample {
+        @Bean
+        MockMvcBuilderCustomizer utf8Config() {
+            return builder -> builder
+                    .addFilters(new CharacterEncodingFilter("UTF-8", true));
+        }
+    }
+}

--- a/app/src/test/java/com/codesoom/project/helper/UTF8EncodingFilter.java
+++ b/app/src/test/java/com/codesoom/project/helper/UTF8EncodingFilter.java
@@ -1,4 +1,4 @@
-package com.codesoom.assignment;
+package com.codesoom.project.helper;
 
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.MockMvcBuilderCustomizer;

--- a/app/src/test/java/com/codesoom/project/web/controller/HelloControllerTest.java
+++ b/app/src/test/java/com/codesoom/project/web/controller/HelloControllerTest.java
@@ -1,5 +1,6 @@
 package com.codesoom.project.web.controller;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
@@ -19,6 +20,7 @@ class HelloControllerTest {
     private MockMvc mockMvc;
 
     @Test
+    @DisplayName("App say hello 테스트")
     void sayHello() throws Exception {
         mockMvc.perform(get("/"))
                 .andExpect(status().isOk())

--- a/app/src/test/java/com/codesoom/project/web/controller/UserControllerTest.java
+++ b/app/src/test/java/com/codesoom/project/web/controller/UserControllerTest.java
@@ -1,0 +1,78 @@
+package com.codesoom.project.web.controller;
+
+import com.codesoom.project.core.application.UserService;
+import com.codesoom.project.core.domain.User;
+import com.codesoom.project.helper.UTF8EncodingFilter;
+import com.codesoom.project.web.dto.UserRegistrationData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.codesoom.project.helper.ApiDocumentUtils.defaultApiDocumentForm;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureRestDocs
+@UTF8EncodingFilter
+@DisplayName("UserController 테스트")
+class UserControllerTest {
+    private static final Long USER_ID = 1L;
+    private static final String USER_EMAIL = "tester@example.com";
+    private static final String USER_NAME = "테스터";
+
+    private static final String CREATE_USER_DTO = "{\"email\":\"%s\",\"name\":\"%s\"}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private UserService userService;
+
+    @BeforeEach
+    void setUp() {
+        given(userService.registerUser(any(UserRegistrationData.class)))
+                .will(invocation -> {
+                    UserRegistrationData registrationData =
+                            invocation.getArgument(0);
+                    return User.builder()
+                            .id(USER_ID)
+                            .email(registrationData.getEmail())
+                            .name(registrationData.getName())
+                            .build();
+                });
+    }
+
+    @Test
+    @DisplayName("정상적인 요청인 경우 신규 회원을 등록한다")
+    void create() throws Exception {
+        mockMvc.perform(
+                post("/users")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(String.format(CREATE_USER_DTO, USER_EMAIL, USER_NAME))
+        )
+                .andExpect(status().isCreated())
+                .andExpect(content().string(
+                        containsString("\"id\":" + USER_ID + "")
+                ))
+                .andExpect(content().string(
+                        containsString("\"email\":\"" + USER_EMAIL + "\"")
+                ))
+                .andExpect(content().string(
+                        containsString("\"name\":\"" + USER_NAME + "\"")
+                ))
+                .andDo(
+                        defaultApiDocumentForm("create-user")
+                );
+    }
+
+}


### PR DESCRIPTION
## 사용자 추가 API 만들기

로그인이 아닌 사용자 정보(email, name)를 추가할 수 있는 API를 만든다.

- UserController 구현
- UserControllerTest 구현
- UserService 구현
- UserServiceTest 구현
- User 도메인 구현
- JpaUserRepository 구현