### PR TITLE
계좌 컨트롤러 생성

### DIFF
--- a/app/src/main/java/com/codesoom/project/core/application/AccountService.java
+++ b/app/src/main/java/com/codesoom/project/core/application/AccountService.java
@@ -2,7 +2,7 @@ package com.codesoom.project.core.application;
 
 import com.codesoom.project.core.domain.Account;
 import com.codesoom.project.core.domain.AccountRepository;
-import com.codesoom.project.web.dto.AccountRegistrationData;
+import com.codesoom.project.web.dto.AccountCreationData;
 import com.github.dozermapper.core.Mapper;
 import org.springframework.stereotype.Service;
 
@@ -25,12 +25,12 @@ public class AccountService {
     /**
      * 신규 계좌를 생성한다.
      *
-     * @param accountRegistrationData 계좌를 생성 위한 데이터
+     * @param accountCreationData 계좌를 생성 위한 데이터
      * @return 등록된 계좌
      */
-    public Account createAccount(AccountRegistrationData accountRegistrationData) {
+    public Account createAccount(AccountCreationData accountCreationData) {
         Account account = accountRepository.save(
-                mapper.map(accountRegistrationData, Account.class));
+                mapper.map(accountCreationData, Account.class));
 
         return account;
     }

--- a/app/src/main/java/com/codesoom/project/web/controller/AccountController.java
+++ b/app/src/main/java/com/codesoom/project/web/controller/AccountController.java
@@ -1,0 +1,18 @@
+package com.codesoom.project.web.controller;
+
+import com.codesoom.project.core.application.AccountService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 계좌에 관련 요청을 처리하고 그에 따른 응답을 담당합니다.
+ */
+@RestController
+@RequestMapping("/accounts")
+public class AccountController {
+    private final AccountService accountService;
+
+    public AccountController(AccountService accountService) {
+        this.accountService = accountService;
+    }
+}

--- a/app/src/main/java/com/codesoom/project/web/controller/AccountController.java
+++ b/app/src/main/java/com/codesoom/project/web/controller/AccountController.java
@@ -1,8 +1,17 @@
 package com.codesoom.project.web.controller;
 
 import com.codesoom.project.core.application.AccountService;
+import com.codesoom.project.core.domain.Account;
+import com.codesoom.project.web.dto.AccountCreationData;
+import com.codesoom.project.web.dto.AccountResultData;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 /**
  * 계좌에 관련 요청을 처리하고 그에 따른 응답을 담당합니다.
@@ -14,5 +23,29 @@ public class AccountController {
 
     public AccountController(AccountService accountService) {
         this.accountService = accountService;
+    }
+
+    /**
+     * 신규 계좌을 등록하고, 등록한 계좌을 반환합니다.
+     *
+     * @param creationData 신규 계좌 정보
+     * @return 등록한 계좌
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    AccountResultData create(@RequestBody @Valid AccountCreationData creationData) {
+        Account account = accountService.createAccount(creationData);
+        return getAccountResultData(account);
+    }
+
+    private AccountResultData getAccountResultData(Account account) {
+        if (account == null) {
+            return null;
+        }
+
+        return AccountResultData.builder()
+                .id(account.getId())
+                .name(account.getName())
+                .build();
     }
 }

--- a/app/src/main/java/com/codesoom/project/web/dto/AccountCreationData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/AccountCreationData.java
@@ -4,15 +4,16 @@ import com.github.dozermapper.core.Mapping;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.validation.constraints.NotBlank;
 
 @Getter
 @Builder
+@NoArgsConstructor
 @AllArgsConstructor
-public class AccountRegistrationData {
+public class AccountCreationData {
     @NotBlank
     @Mapping("name")
     private String name;
 }
-

--- a/app/src/main/java/com/codesoom/project/web/dto/AccountResultData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/AccountResultData.java
@@ -1,0 +1,16 @@
+package com.codesoom.project.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class AccountResultData {
+    private Long id;
+
+    private String name;
+}

--- a/app/src/test/java/com/codesoom/project/core/application/AccountServiceTest.java
+++ b/app/src/test/java/com/codesoom/project/core/application/AccountServiceTest.java
@@ -2,7 +2,7 @@ package com.codesoom.project.core.application;
 
 import com.codesoom.project.core.domain.Account;
 import com.codesoom.project.core.domain.AccountRepository;
-import com.codesoom.project.web.dto.AccountRegistrationData;
+import com.codesoom.project.web.dto.AccountCreationData;
 import com.github.dozermapper.core.DozerBeanMapperBuilder;
 import com.github.dozermapper.core.Mapper;
 import org.junit.jupiter.api.BeforeEach;
@@ -42,7 +42,7 @@ class AccountServiceTest {
     @Test
     @DisplayName("신규 계좌 생성 테스트")
     void createAccount() {
-        AccountRegistrationData registrationData = AccountRegistrationData.builder()
+        AccountCreationData registrationData = AccountCreationData.builder()
                 .name(ACCOUNT_NAME)
                 .build();
 

--- a/app/src/test/java/com/codesoom/project/web/controller/AccountControllerTest.java
+++ b/app/src/test/java/com/codesoom/project/web/controller/AccountControllerTest.java
@@ -1,0 +1,14 @@
+package com.codesoom.project.web.controller;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class AccountControllerTest {
+
+    @BeforeEach
+    void setUp() {
+
+    }
+
+}

--- a/app/src/test/java/com/codesoom/project/web/controller/AccountControllerTest.java
+++ b/app/src/test/java/com/codesoom/project/web/controller/AccountControllerTest.java
@@ -1,14 +1,73 @@
 package com.codesoom.project.web.controller;
 
+import com.codesoom.project.core.application.AccountService;
+import com.codesoom.project.core.domain.Account;
+import com.codesoom.project.helper.UTF8EncodingFilter;
+import com.codesoom.project.web.dto.AccountCreationData;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static com.codesoom.project.helper.ApiDocumentUtils.defaultApiDocumentForm;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+@WebMvcTest(AccountController.class)
+@AutoConfigureRestDocs
+@UTF8EncodingFilter
+@DisplayName("AccountController 테스트")
 class AccountControllerTest {
+    private static final Long ACCOUNT_ID = 1L;
+    private static final String ACCOUNT_NAME = "개인계좌";
+
+    private static final String ACCOUNT_CREATION_DTO = "{\"name\":\"%s\"}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AccountService accountService;
 
     @BeforeEach
     void setUp() {
+        given(accountService.createAccount(any(AccountCreationData.class)))
+                .will(invocation -> {
+                    AccountCreationData creationData = invocation.getArgument(0);
+                    return Account.builder()
+                            .id(ACCOUNT_ID)
+                            .name(creationData.getName())
+                            .build();
+                });
+    }
 
+    @Test
+    @DisplayName("올바른 요청인 경우 신규 계좌 생성 테스트")
+    void create() throws Exception {
+        mockMvc.perform(
+                post("/accounts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(ACCOUNT_CREATION_DTO, ACCOUNT_NAME))
+        )
+                .andExpect(status().isCreated())
+                .andExpect(content().string(
+                        containsString("\"id\":" + ACCOUNT_ID + "")
+                ))
+                .andExpect(content().string(
+                        containsString("\"name\":\"" + ACCOUNT_NAME + "\"")
+                ))
+                .andDo(
+                        defaultApiDocumentForm("create-account")
+                );
     }
 
 }


### PR DESCRIPTION
## AccountController 작성

초기 기능으로 신규 계좌 생성에 대해 구현 완료했습니다.

1. AccountController 테스트를 구현했습니다.
    - POST /accounts, 계좌 생성 API 테스트.
    - 시나리오: "올바른 요청인 경우 신규 계좌 생성.

2. AccountController.create() 구현했습니다.
    - `AccountCreationData`를 request body로써 받고, `AccountResultData`를 응답합니다.

3. AccountCreationData DTO 이름변경.
    - 기존 AccountRegistrationData에서 AccountCreationData로 이름 변경.
    - 더 의미가 분명하게 하기 위해 변경.
