### PR TITLE
카테고리 컨트롤러 생성

### DIFF
--- a/app/src/main/java/com/codesoom/project/web/controller/CategoryController.java
+++ b/app/src/main/java/com/codesoom/project/web/controller/CategoryController.java
@@ -1,8 +1,17 @@
 package com.codesoom.project.web.controller;
 
 import com.codesoom.project.core.application.CategoryService;
+import com.codesoom.project.core.domain.Category;
+import com.codesoom.project.web.dto.CategoryRegistrationData;
+import com.codesoom.project.web.dto.CategoryResultData;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
 
 /**
  * 계좌내역 카테고리에 관련 요청을 처리하고 그에 따른 응답을 담당합니다.
@@ -14,5 +23,29 @@ public class CategoryController {
 
     public CategoryController(CategoryService categoryService) {
         this.categoryService = categoryService;
+    }
+
+    /**
+     * 신규 카테고리를 등록하고, 등록한 카테고리을 반환합니다.
+     *
+     * @param registrationData 신규 카테고리 정보
+     * @return 등록한 카테고리
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    CategoryResultData create(@RequestBody @Valid CategoryRegistrationData registrationData) {
+        Category category = categoryService.createCategory(registrationData);
+        return getCategoryResultData(category);
+    }
+
+    private CategoryResultData getCategoryResultData(Category category) {
+        if (category == null) {
+            return null;
+        }
+
+        return CategoryResultData.builder()
+                .id(category.getId())
+                .name(category.getName())
+                .build();
     }
 }

--- a/app/src/main/java/com/codesoom/project/web/controller/CategoryController.java
+++ b/app/src/main/java/com/codesoom/project/web/controller/CategoryController.java
@@ -10,9 +10,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/categories")
 public class CategoryController {
-//    private final CategoryService categoryService;
-//
-//    public CategoryController(CategoryService categoryService) {
-//        this.categoryService = categoryService;
-//    }
+    private final CategoryService categoryService;
+
+    public CategoryController(CategoryService categoryService) {
+        this.categoryService = categoryService;
+    }
 }

--- a/app/src/main/java/com/codesoom/project/web/dto/CategoryResultData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/CategoryResultData.java
@@ -1,19 +1,16 @@
 package com.codesoom.project.web.dto;
 
-import com.github.dozermapper.core.Mapping;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.validation.constraints.NotBlank;
-
 @Getter
 @Builder
-@NoArgsConstructor
 @AllArgsConstructor
-public class CategoryRegistrationData {
-    @NotBlank
-    @Mapping("name")
+@NoArgsConstructor
+public class CategoryResultData {
+    private Long id;
+
     private String name;
 }

--- a/app/src/test/java/com/codesoom/project/web/controller/CategoryControllerTest.java
+++ b/app/src/test/java/com/codesoom/project/web/controller/CategoryControllerTest.java
@@ -1,0 +1,73 @@
+package com.codesoom.project.web.controller;
+
+import com.codesoom.project.core.application.CategoryService;
+import com.codesoom.project.core.domain.Category;
+import com.codesoom.project.helper.UTF8EncodingFilter;
+import com.codesoom.project.web.dto.CategoryRegistrationData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.codesoom.project.helper.ApiDocumentUtils.defaultApiDocumentForm;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CategoryController.class)
+@AutoConfigureRestDocs
+@UTF8EncodingFilter
+@DisplayName("CategoryController 테스트")
+class CategoryControllerTest {
+    private static final Long CATEGORY_ID = 1L;
+    private static final String CATEGORY_NAME = "지출";
+
+    private static final String CATEGORY_REGISTRATION_DTO = "{\"name\":\"%s\"}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private CategoryService categoryService;
+
+    @BeforeEach
+    void setUp() {
+        given(categoryService.createCategory(any(CategoryRegistrationData.class)))
+                .will(invocation -> {
+                    CategoryRegistrationData registrationData =
+                            invocation.getArgument(0);
+                    return Category.builder()
+                            .id(CATEGORY_ID)
+                            .name(registrationData.getName())
+                            .build();
+                });
+    }
+
+    @Test
+    @DisplayName("정상적인 요청인 경우 신규 카테고리를 등록한다")
+    void create() throws Exception {
+        mockMvc.perform(
+                post("/categories")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(String.format(CATEGORY_REGISTRATION_DTO, CATEGORY_NAME))
+        )
+                .andExpect(status().isCreated())
+                .andExpect(content().string(
+                        containsString("\"id\":" + CATEGORY_ID + "")
+                ))
+                .andExpect(content().string(
+                        containsString("\"name\":\"" + CATEGORY_NAME + "\"")
+                ))
+                .andDo(
+                        defaultApiDocumentForm("create-category")
+                );
+    }
+}


### PR DESCRIPTION
## CategoryController 구현

계좌내역 카테고리에 관련 요청을 처리하고 그에 따른 응답을 담당하는 컨트롤러입니다.

    - Controller.create() 메서드 생성, 이에 따른 테스트 작성.
    - Appclication 정상 작동 및 카테고리 신규 생성 테스트 통과.