### PR TITLE
도메인 JPA ID 생성 전략 변경

### DIFF
--- a/app/src/main/java/com/codesoom/project/core/domain/Account.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/Account.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 /**
@@ -19,7 +20,7 @@ import javax.persistence.Id;
 @AllArgsConstructor
 public class Account {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Builder.Default

--- a/app/src/main/java/com/codesoom/project/core/domain/Category.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/Category.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 /**
@@ -19,7 +20,7 @@ import javax.persistence.Id;
 @AllArgsConstructor
 public class Category {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @Builder.Default

--- a/app/src/main/java/com/codesoom/project/core/domain/User.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/User.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.validation.constraints.NotNull;
 
@@ -17,7 +18,7 @@ import javax.validation.constraints.NotNull;
 @AllArgsConstructor
 public class User {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotNull

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -5,4 +5,4 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: create


### PR DESCRIPTION
## 도메인 ID(`@Id`) 생성 전략 변경

- `@GeneratedValue` -> `@Gernerated(strategy = GenerationType.IDENTITY)`

- 기본 설정으로 한 경우, 모든 도메인 ID가 같이 auto increament되는 이슈 발생. 
  예) 시나리오, 'A라는 도메인 데이터를 추가했을 때, 다른 도메인의 ID도 함께 증가'
  1. A 추가: ID, 1
  2. B 추가: ID, 2
  3. A 추가: ID, 3

- **[해결 완료]**