### PR TITLE
계좌내역 서비스 생성

### DIFF
--- a/app/src/main/java/com/codesoom/project/core/application/AccountBookService.java
+++ b/app/src/main/java/com/codesoom/project/core/application/AccountBookService.java
@@ -1,0 +1,34 @@
+package com.codesoom.project.core.application;
+
+import com.codesoom.project.core.domain.AccountBookRepository;
+import com.github.dozermapper.core.Mapper;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+/**
+ * 계좌내역에 관한 유즈케이스를 담당합니다.
+ */
+@Service
+@Transactional
+public class AccountBookService {
+    private final Mapper mapper;
+    private final AccountBookRepository accountBookRepository;
+
+    public AccountBookService(Mapper mapper, AccountBookRepository accountBookRepository) {
+        this.mapper = mapper;
+        this.accountBookRepository = accountBookRepository;
+    }
+}
+    /**
+     * 신규 계좌내역를 추가.
+     *
+     * @param registrationData 계좌내역를 생성 위한 데이터
+     * @return 등록된 계좌내역
+
+    public Account addAccountBookItem(AccountBookItemRegistrationData registrationData) {
+        Account account = accountBookRepository.save(
+                mapper.map(accountCreationData, Account.class));
+
+        return account;
+    }*/

--- a/app/src/main/java/com/codesoom/project/web/dto/AccountBookItemRegistrationData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/AccountBookItemRegistrationData.java
@@ -1,0 +1,22 @@
+package com.codesoom.project.web.dto;
+
+import com.github.dozermapper.core.Mapping;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.validation.constraints.NotNull;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountBookItemRegistrationData {
+    @NotNull
+    @Mapping("amount")
+    private Integer amount;
+
+    @Mapping("description")
+    private String description;
+}

--- a/app/src/test/java/com/codesoom/project/core/application/AccountBookServiceTest.java
+++ b/app/src/test/java/com/codesoom/project/core/application/AccountBookServiceTest.java
@@ -1,0 +1,67 @@
+package com.codesoom.project.core.application;
+
+import com.codesoom.project.core.domain.Account;
+import com.codesoom.project.core.domain.AccountBook;
+import com.codesoom.project.core.domain.AccountBookRepository;
+import com.codesoom.project.core.domain.AccountRepository;
+import com.codesoom.project.web.dto.AccountBookItemRegistrationData;
+import com.codesoom.project.web.dto.AccountCreationData;
+import com.github.dozermapper.core.DozerBeanMapperBuilder;
+import com.github.dozermapper.core.Mapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+@DisplayName("AccountBookService 테스트")
+class AccountBookServiceTest {
+    private final Long ID = 1L;
+    private final Integer AMOUNT = 3000000;
+    private final String DESCIPTION = "월급";
+
+    private AccountBookService accountBookService;
+
+    private final AccountBookRepository accountBookRepository
+            = mock(AccountBookRepository.class);
+
+    @BeforeEach
+    void setUp() {
+        Mapper mapper = DozerBeanMapperBuilder.buildDefault();
+
+        accountBookService = new AccountBookService(mapper, accountBookRepository);
+
+        given(accountBookRepository.save(any(AccountBook.class)))
+                .will(invocation -> {
+                    AccountBook source = invocation.getArgument(0);
+                    return AccountBook.builder()
+                            .id(ID)
+                            .amount(AMOUNT)
+                            .description(DESCIPTION)
+                            .build();
+                });
+    }
+
+    @Test
+    @DisplayName("올바른 요청시 신규 계좌내역 추가 테스트")
+    void addAccountHistory() throws Exception {
+        AccountBookItemRegistrationData registrationData =
+                AccountBookItemRegistrationData.builder()
+                        .amount(AMOUNT)
+                        .description(DESCIPTION)
+                        .build();
+
+        AccountBook accountBook = accountBookService.addAccountBookItem(registrationData);
+
+        verify(accountBookRepository).save(any(AccountBook.class));
+
+        assertThat(accountBook.getId()).isEqualTo(ID);
+        assertThat(accountBook.getAmount()).isEqualTo(AMOUNT);
+        assertThat(accountBook.getDescription()).isEqualTo(DESCIPTION);
+    }
+}

--- a/app/src/test/java/com/codesoom/project/core/application/AccountServiceTest.java
+++ b/app/src/test/java/com/codesoom/project/core/application/AccountServiceTest.java
@@ -41,7 +41,7 @@ class AccountServiceTest {
 
     @Test
     @DisplayName("신규 계좌 생성 테스트")
-    void createAccount() {
+    void addAccountBookItem() {
         AccountCreationData registrationData = AccountCreationData.builder()
                 .name(ACCOUNT_NAME)
                 .build();


### PR DESCRIPTION
## AccountBookService 생성

이에 따른 테스트(`AccountBookServiceTest`)를 생성했습니다.

- '신규 계좌내역 추가 테스트'를 위해 `addAccountHistory` 메서드 테스트.
  - 신규 계좌내역 추가 시 필요한 DTO, `AccountBookItemRegistrationData` 생성.
  - 정상적으로 추가됐을 때, AccountBook ID를 부여한 객체 반환.