### PR TITLE
계좌내역에 대한 컨트롤러 추가

### DIFF
--- a/app/src/main/java/com/codesoom/project/web/controller/AccountBookController.java
+++ b/app/src/main/java/com/codesoom/project/web/controller/AccountBookController.java
@@ -1,0 +1,56 @@
+package com.codesoom.project.web.controller;
+
+import com.codesoom.project.core.application.AccountBookService;
+import com.codesoom.project.core.application.AccountService;
+import com.codesoom.project.core.domain.Account;
+import com.codesoom.project.core.domain.AccountBook;
+import com.codesoom.project.web.dto.AccountBookItemRegistrationData;
+import com.codesoom.project.web.dto.AccountBookResultData;
+import com.codesoom.project.web.dto.AccountCreationData;
+import com.codesoom.project.web.dto.AccountResultData;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+
+/**
+ * 계좌내역에 관련 요청을 처리하고 그에 따른 응답을 담당합니다.
+ */
+@RestController
+@RequestMapping("/accountBooks")
+public class AccountBookController {
+    private final AccountBookService accountBookService;
+
+    public AccountBookController(AccountBookService accountBookService) {
+        this.accountBookService = accountBookService;
+    }
+
+    /**
+     * 신규 계좌내역을 추가하고, 등록한 계좌내역을 반환합니다.
+     *
+     * @param registrationData 신규 계좌 정보
+     * @return 등록한 계좌
+     */
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    AccountBookResultData add(@RequestBody @Valid AccountBookItemRegistrationData registrationData) {
+        AccountBook accountBook = accountBookService.addAccountBookItem(registrationData);
+        return getAccountBookResultData(accountBook);
+    }
+
+    private AccountBookResultData getAccountBookResultData(AccountBook accountBook) {
+        if (accountBook == null) {
+            return null;
+        }
+
+        return AccountBookResultData.builder()
+                .id(accountBook.getId())
+                .amount(accountBook.getAmount())
+                .description(accountBook.getDescription())
+                .build();
+    }
+}

--- a/app/src/main/java/com/codesoom/project/web/dto/AccountBookResultData.java
+++ b/app/src/main/java/com/codesoom/project/web/dto/AccountBookResultData.java
@@ -1,0 +1,18 @@
+package com.codesoom.project.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AccountBookResultData {
+    private Long id;
+
+    private Integer amount;
+
+    private String description;
+}

--- a/app/src/test/java/com/codesoom/project/web/controller/AccountBookControllerTest.java
+++ b/app/src/test/java/com/codesoom/project/web/controller/AccountBookControllerTest.java
@@ -1,0 +1,81 @@
+package com.codesoom.project.web.controller;
+
+import com.codesoom.project.core.application.AccountBookService;
+import com.codesoom.project.core.domain.AccountBook;
+import com.codesoom.project.helper.UTF8EncodingFilter;
+import com.codesoom.project.web.dto.AccountBookItemRegistrationData;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.codesoom.project.helper.ApiDocumentUtils.defaultApiDocumentForm;
+import static org.hamcrest.Matchers.containsString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AccountBookController.class)
+@AutoConfigureRestDocs
+@UTF8EncodingFilter
+@DisplayName("AccountBookController 테스트")
+class AccountBookControllerTest {
+    private static final Long ID = 1L;
+    private static final Integer AMOUNT = 3000000;
+    private static final String DESCRIPTION = "월급";
+
+    private static final String ACCOUNTBOOK_ADD_DTO =
+            "{\"amount\":\"%s\", \"description\":\"%s\"}";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private AccountBookService accountBookService;
+
+    @BeforeEach
+    void setUp() {
+        given(accountBookService.addAccountBookItem(
+                any(AccountBookItemRegistrationData.class))
+        )
+                .will(invocation -> {
+                    AccountBookItemRegistrationData registrationData
+                            = invocation.getArgument(0);
+                    return AccountBook.builder()
+                            .id(ID)
+                            .amount(registrationData.getAmount())
+                            .description(registrationData.getDescription())
+                            .build();
+                });
+    }
+
+    @Test
+    @DisplayName("올바른 요청인 경우 신규 계좌 생성 테스트")
+    void add() throws Exception {
+        mockMvc.perform(
+                post("/accountBooks")
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(String.format(ACCOUNTBOOK_ADD_DTO, AMOUNT, DESCRIPTION))
+        )
+                .andExpect(status().isCreated())
+                .andExpect(content().string(
+                        containsString("\"id\":" + ID + "")
+                ))
+                .andExpect(content().string(
+                        containsString("\"amount\":" + AMOUNT + "")
+                ))
+                .andExpect(content().string(
+                        containsString("\"description\":\"" + DESCRIPTION + "\"")
+                ))
+                .andDo(
+                        defaultApiDocumentForm("create-accountbook-item")
+                );
+    }
+}


### PR DESCRIPTION
## AccountBookController 작성

계좌내역에 대한 다양한 요청 처리를 담당하는 `AccountBookController` 컨트롤러를 생성했습니다.

- 이에 따른, 테스트를 작성했으며, 테스트 시나리오는 아래와 같습니다.
  - '올바른 요청인 경우 신규 계좌를 생성합니다.'
  - 요청 데이터, `{"amount":"%s", "description":"%s"}`
  - 성공 시, CREATED 응답.