### PR TITLE
계좌와 계좌내역 간 연관관계 생성

### DIFF
--- a/app/src/main/java/com/codesoom/project/core/domain/Account.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/Account.java
@@ -9,6 +9,9 @@ import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 계좌 도메인
@@ -25,4 +28,7 @@ public class Account {
 
     @Builder.Default
     private String name = "";
+
+    @OneToMany(mappedBy = "account")
+    private List<AccountLedger> ledgers = new ArrayList<AccountLedger>();
 }

--- a/app/src/main/java/com/codesoom/project/core/domain/AccountLedger.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/AccountLedger.java
@@ -4,11 +4,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.context.expression.CachedExpressionEvaluator;
 
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 
 /**
  * 계좌내역 도메인
@@ -28,4 +31,8 @@ public class AccountLedger {
 
     @Builder.Default
     private String description = "";
+
+    @ManyToOne
+    @JoinColumn(name = "account_id")
+    private Account account;
 }


### PR DESCRIPTION
## 계좌와 계좌내역 간 연관관계

- 1:N, 일대다 맵핑, 계좌(1)에 계좌내역(N)이 여러 개 있을 수 있습니다.
- `Account` 도메인에는 `@OneToMany(mappedBy="account")`를 맵핑.
- `AccountLedger` 도메인에는 `@ManyToOne @JoinColumn(name = "account_id")`를 맵핑.