### PR TITLE
계좌내역과 카테고리 간 연관관계 생성.

### DIFF
--- a/app/src/main/java/com/codesoom/project/core/domain/AccountLedger.java
+++ b/app/src/main/java/com/codesoom/project/core/domain/AccountLedger.java
@@ -4,14 +4,15 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.context.expression.CachedExpressionEvaluator;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
+import javax.persistence.OneToOne;
 
 /**
  * 계좌내역 도메인
@@ -27,12 +28,17 @@ public class AccountLedger {
     private Long id;
 
     @Builder.Default
+    @Column(nullable = false)
     private Integer amount = 0;
 
     @Builder.Default
     private String description = "";
 
     @ManyToOne
-    @JoinColumn(name = "account_id")
+    @JoinColumn(name = "account_id", nullable = false)
     private Account account;
+
+    @OneToOne
+    @JoinColumn(name = "category_id", nullable = false)
+    private Category category;
 }


### PR DESCRIPTION
## 계좌내역과 카테고리 간 연관관계

- 하나의 계좌내역은 한 개의 카테고리를 가질 수 있습니다.

- 계좌내역(1) : 카테고리(1) 연관 관계이기 때문에, `@OneToOne`를 통해 맵핑합니다.

- 또한, 계좌내역에서 카테고리를 조회하기 때문에 단방향으로 정의합니다.